### PR TITLE
allow getifaddrs() to return more address families

### DIFF
--- a/common/libnwamui.c
+++ b/common/libnwamui.c
@@ -1665,6 +1665,11 @@ nwamui_util_ncp_init_acquired_ip(NwamuiNcp *ncp)
     if (getifaddrs(&ifap) == 0) {
 
         for (idx = ifap; idx; idx = idx->ifa_next) {
+            if (idx->ifa_addr->sa_family != AF_INET
+              && idx->ifa_addr->sa_family != AF_INET6) {
+                continue;
+            }
+
             ncu = nwamui_ncp_get_ncu_by_device_name(ncp, idx->ifa_name);
 
             if (ncu) {


### PR DESCRIPTION
This should fix nwam-manager after https://github.com/illumos/illumos-gate/commit/e34d8872f4a713d904a4b34fb081060d1a7eba62.
The new `getifaddrs()` can return other address families than AF_INET or AF_INET6 (namely AF_LINK).

I have not build or tested this change yet as I'll need some dev setup first, but wanted to get this fix out  for review now.

Sorry for breaking this in the first place, I did survey some consumers of getifaddrs before integrating but missed that one. 